### PR TITLE
[v3.0.0] Wait for upload to be marked as completed before completing action

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,10 @@ jobs:
 # Android
 
 ```yaml
-- uses: mobile-dev-inc/action-upload@v2.3.1
+- uses: mobile-dev-inc/action-upload@v3.0.0
   with:
     api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
     app-file: app/build/outputs/apk/debug/app-debug.apk
-    # [optional] Specify name if you want to override the default name which is either PR title, commit message or sha
-    name: ${{ github.sha }} 
 ```
 
 `app-file` should point to an x86 compatible APK file
@@ -50,25 +48,21 @@ jobs:
 Include the Proguard mapping file to deobfuscate Android performance traces:
 
 ```yaml
-- uses: mobile-dev-inc/action-upload@v2.3.1
+- uses: mobile-dev-inc/action-upload@v3.0.0
   with:
     api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
     app-file: app/build/outputs/apk/release/app-release.apk
     mapping-file: app/build/outputs/mapping/release/mapping.txt
-    # [optional] Specify name if you want to override the default name which is either PR title, commit message or sha
-    name: ${{ github.sha }} 
 ```
 
 # iOS
 
 ```yaml
-- uses: mobile-dev-inc/action-upload@v2.3.1
+- uses: mobile-dev-inc/action-upload@v3.0.0
   with:
     api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
     app-file: <app_name>.app
     mapping-file: <app_name>.app.dSYM
-    # [optional] Specify name if you want to override the default name which is either PR title, commit message or sha    
-    name: ${{ github.sha }} 
 ```
 
 `app-file` should point to an x86 compatible Simulator build packaged in a `zip` archive
@@ -80,11 +74,38 @@ Include the Proguard mapping file to deobfuscate Android performance traces:
 By default, the action is looking for a `.mobiledev` folder with Maestro flows in the root directory of the project. If you would like to customize this behaviour, you can override it with a `workspace` argument:
 
 ```yaml
-- uses: mobile-dev-inc/action-upload@v2.3.1
+- uses: mobile-dev-inc/action-upload@v3.0.0
   with:
     api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
     app-file: app.zip
     workspace: myApp/.mobiledev
-    # [optional] Specify name if you want to override the default name which is either PR title, commit message or sha
-    name: ${{ github.sha }} 
+```
+
+# Custom name
+A name will automatically be provided according to the following order:
+1. If it is a Pull Request, use Pull Request title as name
+2. If it is a normal push, use commit message as name
+3. If for some reason the commit message is not available, use the commit SHA as name
+
+If you want to override this behaviour and specify your own name, you can do so by setting the `name` argument:
+
+```yaml
+- uses: mobile-dev-inc/action-upload@v3.0.0
+  with:
+    api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
+    app-file: app.zip
+    workspace: myApp/.mobiledev
+    name: customName
+```
+
+
+# Don't wait until Upload has completed
+If you don't want the action to wait until the Upload has been completed as is the default behaviour, set the `wait` argument to `false`:
+
+```yaml
+- uses: mobile-dev-inc/action-upload@v3.0.0
+  with:
+    api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
+    app-file: app.zip
+    wait: false
 ```

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ If you want to override this behaviour and specify your own name, you can do so 
 ```
 
 
-# Don't wait until Upload has completed
-If you don't want the action to wait until the Upload has been completed as is the default behaviour, set the `wait` argument to `false`:
+# Run in async mode
+If you don't want the action to wait until the Upload has been completed as is the default behaviour, set the `async` argument to `true`:
 
 ```yaml
 - uses: mobile-dev-inc/action-upload@v3.0.0
   with:
     api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
     app-file: app.zip
-    wait: false
+    async: true
 ```

--- a/StatusPoller.ts
+++ b/StatusPoller.ts
@@ -1,0 +1,77 @@
+import * as core from '@actions/core'
+import ApiClient, { BenchmarkStatus, UploadStatusError } from "./ApiClient";
+
+const WAIT_TIMEOUT_MS = 1000 * 60 * 30 // 30 minutes
+const INTERVAL_MS = 10000 // 10 seconds
+
+export default class StatusPoller {
+  timeout: NodeJS.Timeout | undefined
+
+  constructor(
+    private client: ApiClient,
+    private uploadId: string,
+    private viewUploadInConsoleStr: string
+  ) { }
+
+  markFailed(msg: string) {
+    core.setFailed(msg)
+  }
+
+  async poll(
+    sleep: number,
+    prevErrorCount: number = 0
+  ) {
+    try {
+      const { completed, status } = await this.client.getUploadStatus(this.uploadId)
+      if (completed) {
+        this.teardown()
+        if (status === BenchmarkStatus.ERROR) {
+          this.markFailed(`Upload failed. ${this.viewUploadInConsoleStr}`)
+        } else {
+          console.log(`Upload completed! ${this.viewUploadInConsoleStr}`)
+        }
+      } else {
+        console.log(`Upload is ${status.toLowerCase()}, continuing to wait`)
+        setTimeout(() => this.poll(sleep), sleep)
+      }
+    } catch (error) {
+      if (error instanceof UploadStatusError) {
+        if (error.status === 429) {
+          // back off through extending sleep duration with 25%
+          const newSleep = sleep * 1.25
+          setTimeout(() => this.poll(newSleep, prevErrorCount), newSleep)
+        } else if (error.status >= 500) {
+          if (prevErrorCount < 3) {
+            setTimeout(() => this.poll(sleep, prevErrorCount++), sleep)
+          } else {
+            this.markFailed(`Request to get status information failed with status code ${error.status}: ${error.text}`)
+          }
+        } else {
+          this.markFailed(`Could not get Upload status. Received error ${error}. ${this.viewUploadInConsoleStr}`)
+        }
+      } else {
+        this.markFailed(`Could not get Upload status. Received error ${error}. ${this.viewUploadInConsoleStr}`)
+      }
+    }
+  }
+
+  registerTimeout() {
+    this.timeout = setTimeout(() => {
+      this.markFailed(`Timed out waiting for Upload to complete. ${this.viewUploadInConsoleStr}`)
+    }, WAIT_TIMEOUT_MS)
+  }
+
+  teardown() {
+    this.timeout && clearTimeout(this.timeout)
+  }
+
+  startPolling() {
+    try {
+      this.poll(INTERVAL_MS)
+    } catch (err) {
+      this.markFailed(err instanceof Error ? err.message : `${err}`)
+    }
+
+    this.registerTimeout()
+  }
+}

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   env:
     description: 'Set of key=value entries to pass as an input to Maestro flows'
     required: false
+  async:
+    description: 'Whether to run Upload in async fashion and not block until completed'
+    required: false
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,10 @@
 import * as core from '@actions/core'
-import ApiClient, { UploadRequest } from './ApiClient'
+import ApiClient, { BenchmarkStatus, UploadStatusError, UploadRequest } from './ApiClient'
 import { validateAppFile } from './app_file';
 import { zipFolder, zipIfFolder } from './archive_utils';
 import { getParameters } from './params';
 import { existsSync } from 'fs';
+import StatusPoller from './StatusPoller';
 
 const knownAppTypes = ['ANDROID_APK', 'IOS_BUNDLE']
 
@@ -16,6 +17,10 @@ async function createWorkspaceZip(workspaceFolder: string | null): Promise<strin
   console.log("Packaging .mobiledev folder")
   await zipFolder(resolvedWorkspaceFolder, 'workspace.zip');
   return 'workspace.zip'
+}
+
+export function getViewUploadInConsoleStr(uploadId: string, teamId: string, appId: string): string {
+  return `Visit the web console for more details about the upload: https://console.mobile.dev/uploads/${uploadId}?teamId=${teamId}&appId=${appId}`
 }
 
 
@@ -31,7 +36,8 @@ async function run() {
     repoOwner,
     repoName,
     pullRequestId,
-    env
+    env,
+    async
   } = await getParameters()
 
   const appFile = await validateAppFile(
@@ -55,12 +61,16 @@ async function run() {
     env: env
   }
 
-  await client.uploadRequest(
+  const { uploadId, teamId, targetId: appId } = await client.uploadRequest(
     request,
     appFile.path,
     workspaceZip,
     mappingFile && await zipIfFolder(mappingFile),
   )
+  const viewUploadStr = getViewUploadInConsoleStr(uploadId, teamId, appId)
+  console.log(viewUploadStr)
+
+  !async && new StatusPoller(client, uploadId, viewUploadStr).startPolling()
 }
 
 run().catch(e => {

--- a/params.ts
+++ b/params.ts
@@ -3,7 +3,6 @@ import * as core from '@actions/core';
 import { AppFile, validateMappingFile } from './app_file';
 import { PushEvent } from '@octokit/webhooks-definitions/schema'
 
-
 export type Params = {
   apiKey: string,
   apiUrl: string,
@@ -16,6 +15,7 @@ export type Params = {
   repoOwner: string
   pullRequestId?: string,
   env?: { [key: string]: string },
+  async?: boolean
 }
 
 function getBranchName(): string {
@@ -78,8 +78,8 @@ export async function getParameters(): Promise<Params> {
   const mappingFileInput = core.getInput('mapping-file', { required: false })
   const workspaceFolder = core.getInput('workspace', { required: false })
   const mappingFile = mappingFileInput && validateMappingFile(mappingFileInput)
+  const async = core.getInput('async', { required: false }) === 'true'
 
-  var env: { [key: string]: string } = {}
   var env: { [key: string]: string } = {}
   env = core.getMultilineInput('env', { required: false })
     .map(it => {
@@ -100,5 +100,5 @@ export async function getParameters(): Promise<Params> {
   const repoOwner = getRepoOwner();
   const repoName = getRepoName();
   const pullRequestId = getPullRequestId()
-  return { apiUrl, name, apiKey, appFilePath, mappingFile, workspaceFolder, branchName, repoOwner, repoName, pullRequestId, env }
+  return { apiUrl, name, apiKey, appFilePath, mappingFile, workspaceFolder, branchName, repoOwner, repoName, pullRequestId, env, async }
 }


### PR DESCRIPTION
- Integrate with mobile.dev API status endpoint to continuously poll for upload status and only complete action once the upload is marked as completed
- Add new parameter `wait: boolean` that when explicitly set to `false` overrides this behaviour and does not wait for upload to be completed
- Update `README.md`